### PR TITLE
Fix the navbar inclusion.

### DIFF
--- a/soupault.conf
+++ b/soupault.conf
@@ -20,7 +20,7 @@
 #   index = true
 #   index_selector = "div#index"
 
-[widget.navbar]
+[widgets.navbar]
   widget = "include"
   selector = "#navver"
   file = "templates/nav-menu.html"

--- a/templates/nav-menu.html
+++ b/templates/nav-menu.html
@@ -1,6 +1,1 @@
-<html>
-    <head></head>
-    <body>
-        <p>this is a nav menu?</p>
-    </body>
-</html>
+<p>this is a nav menu?</p>


### PR DESCRIPTION
As discussed in the soupault #3, the widget config syntax is missing one letter, and the include file has extra HTML wrapping.